### PR TITLE
.gitignoreに.tags*を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ config/environments/*.local.yml
 
 .idea
 .DS_Store
+.tags*


### PR DESCRIPTION
ctagが作るtagファイルをgitの管理から除去
